### PR TITLE
ActiveSupport::SecureRandom deprecated in 3.1, removed in 3.2

### DIFF
--- a/app/models/model_mixin.rb
+++ b/app/models/model_mixin.rb
@@ -96,7 +96,7 @@ module ModelMixin
     private
 
     def url_friendly_token # :nodoc:
-      ActiveSupport::SecureRandom.base64(10).tr('+/=', 'xyz')
+      SecureRandom.base64(10).tr('+/=', 'xyz')
     end
   end
 


### PR DESCRIPTION
Changed the reference to SecureRandom, see https://github.com/rails/rails/commit/1170cceaaec8c0c8aef173913405be1456e4b2be#activesupport/lib/active_support
